### PR TITLE
2-Wire otanonce fix.

### DIFF
--- a/src/include/target/Frsky_TX_R9M.h
+++ b/src/include/target/Frsky_TX_R9M.h
@@ -30,7 +30,7 @@
 #define GPIO_PIN_LED_GREEN              PA12 // Green LED
 //#define GPIO_PIN_BUTTON                 PA8 // pullup e.g. LOW when pressed
 #define GPIO_PIN_SLAVE_INTERRUPT        PA8
-
+#define GPIO_PIN_SLAVE_INTERRUPT_SYNC_OTA PA3
 #define GPIO_PIN_SLAVE_SYNC             PA2 // TODO: debug
 // #define GPIO_PIN_TXD                    PA3
 // #define GPIO_PIN_RXD                    PA4

--- a/src/src/tx_main.cpp
+++ b/src/src/tx_main.cpp
@@ -37,7 +37,6 @@
 #define MILLS_82 (82)
 
 #define MILLS_122 (122)
-#define SLAVE_TX
 
 #define MSP_PACKET_SEND_INTERVAL 10LU
 /// define some libs to use ///


### PR DESCRIPTION
Master drives timing on both TXs and syncs slave if timing from last trigger is within 3ms.

Slave disables local timer if master is present and transmits on Master intgerrupt, syncs Otanonce from master if intgerrupt is within 3ms from last packet intgerupt.

Slave re-enables local timer if master stops interrupting.